### PR TITLE
Make the asmjs version run and validate even when there's no SIMD available 

### DIFF
--- a/js/mandelbrot-asm.js
+++ b/js/mandelbrot-asm.js
@@ -14,9 +14,7 @@ if (typeof Math.fround == 'undefined') {
   Math.fround = function(x) { return x };
 }
 if (typeof SIMD == 'undefined') {
-  // TODO maybe use the polyfill?
   alert('SIMD not implemented in this browser. SIMD speedup button is disabled');
-//  throw 'SIMD not implemented in this browser';
 } else {
   // Polyfill coercive ctor
   try {
@@ -119,36 +117,6 @@ function asmjsModule (global, imp, buffer) {
     b8[0x00ffffff] = 0;
   }
 
-  function mandelPixelX1 (xf, yf, yd, max_iterations) {
-    xf = toF(xf);
-    yf = toF(yf);
-    yd = toF(yd);
-    max_iterations = max_iterations | 0;
-
-    var z_re  = toF(0), z_im  = toF(0);
-    var z_re2 = toF(0), z_im2 = toF(0);
-    var new_re = toF(0), new_im = toF(0);
-    var count = 0, i = 0, mi = 0;
-
-    z_re  = xf;
-    z_im  = yf;
-
-    for (i = 0; (i | 0) < (max_iterations | 0); i = (i + 1) | 0) {
-      z_re2 = toF(z_re * z_re);
-      z_im2 = toF(z_im * z_im);
-
-      if (toF(z_re2 + z_im2) > toF(4))
-        break;
-
-      new_re = toF(z_re2 - z_im2);
-      new_im = toF(toF(z_re * toF(2)) * z_im);
-      z_re   = toF(xf + new_re);
-      z_im   = toF(yf + new_im);
-      count  = (count + 1) | 0;
-    }
-    return count | 0;
-  }
-
   function mapColorAndSetPixel (x, y, width, value, max_iterations) {
     x = x | 0;
     y = y | 0;
@@ -173,48 +141,6 @@ function asmjsModule (global, imp, buffer) {
     b8[(index & mk0) + 1 >> 0] = g;
     b8[(index & mk0) + 2 >> 0] = b;
     b8[(index & mk0) + 3 >> 0] = 255;
-  }
-
-  function mandelColumnX1 (x, width, height, xf, yf, yd, max_iterations) {
-    x = x | 0;
-    width = width | 0;
-    height = height | 0;
-    xf = toF(xf);
-    yf = toF(yf);
-    yd = toF(yd);
-    max_iterations = max_iterations | 0;
-
-    var y = 0, m = 0;
-
-    yd = toF(yd);
-    for (y = 0; (y | 0) < (height | 0); y = (y + 1) | 0) {
-      m = mandelPixelX1(toF(xf), toF(yf), toF(yd), max_iterations) | 0;
-      mapColorAndSetPixel(x | 0, y | 0, width, m, max_iterations);
-      yf = toF(yf + yd);
-    }
-  }
-
-  function mandelX1 (width, height, xc, yc, scale, max_iterations) {
-    width = width | 0;
-    height = height | 0;
-    xc = toF(xc);
-    yc = toF(yc);
-    scale = toF(scale);
-    max_iterations = max_iterations | 0;
-
-    var x0 = toF(0), y0 = toF(0), xd = toF(0), yd = toF(0), xf = toF(0);
-    var x = 0;
-
-    x0 = toF(xc - toF(scale * toF(1.5)));
-    y0 = toF(yc - scale);
-    xd = toF(toF(scale * toF(3)) / toF(width >>> 0));
-    yd = toF(toF(scale * toF(2)) / toF(height >>> 0));
-    xf = x0;
-
-    for (x = 0; (x | 0) < (width | 0); x = (x + 1) | 0) {
-      mandelColumnX1(x, width, height, xf, y0, yd, max_iterations);
-      xf = toF(xf + xd);
-    }
   }
 
   function mandelPixelX4 (xf, yf, yd, max_iterations) {
@@ -278,14 +204,13 @@ function asmjsModule (global, imp, buffer) {
     }
   }
 
-  function mandel (width, height, xc, yc, scale, max_iterations, use_simd) {
+  function mandel (width, height, xc, yc, scale, max_iterations) {
     width = width | 0;
     height = height | 0;
     xc = toF(xc);
     yc = toF(yc);
     scale = toF(scale);
     max_iterations = max_iterations | 0;
-    use_simd = use_simd | 0;
 
     var x0 = toF(0), y0 = toF(0);
     var xd = toF(0), yd = toF(0);
@@ -299,10 +224,7 @@ function asmjsModule (global, imp, buffer) {
     xf = x0;
 
     for (x = 0; (x | 0) < (width | 0); x = (x + 1) | 0) {
-      if (use_simd)
-        mandelColumnX4(x, width, height, xf, y0, yd, max_iterations);
-      else
-        mandelColumnX1(x, width, height, xf, y0, yd, max_iterations);
+      mandelColumnX4(x, width, height, xf, y0, yd, max_iterations);
       xf = toF(xf + xd);
     }
   }
@@ -360,7 +282,7 @@ function nonSimdAsmjsModule (global, imp, buffer) {
 
     var rgb = 0, r = 0, g = 0, b = 0, index = 0;
 
-    index = (((imul((width >>> 0), (y >>> 0)) + x) | 0) * 4) | 0;
+    index = ((((imul((width >>> 0), (y >>> 0)) | 0) + x) | 0) * 4) | 0;
     if ((value | 0) == (max_iterations | 0)) {
       r = 0;
       g = 0;
@@ -419,14 +341,13 @@ function nonSimdAsmjsModule (global, imp, buffer) {
     }
   }
 
-  function mandel (width, height, xc, yc, scale, max_iterations, use_simd) {
+  function mandel (width, height, xc, yc, scale, max_iterations) {
     width = width | 0;
     height = height | 0;
     xc = toF(xc);
     yc = toF(yc);
     scale = toF(scale);
     max_iterations = max_iterations | 0;
-    use_simd = use_simd | 0;
 
     var x0 = toF(0), y0 = toF(0);
     var xd = toF(0), yd = toF(0);
@@ -448,17 +369,16 @@ function nonSimdAsmjsModule (global, imp, buffer) {
   return mandel;
 }
 
-var mandel;
-if (typeof SIMD === "undefined") {
-  mandel = nonSimdAsmjsModule(this, {}, buffer);
-}
-else {
-  mandel = asmjsModule (this, {}, buffer);
-}
+var HAS_SIMD = typeof SIMD !== 'undefined';
+var mandelSimd = (HAS_SIMD && asmjsModule (this, {}, buffer)) || null;
+var mandelNonSimd = nonSimdAsmjsModule (this, {}, buffer);
 
 function drawMandelbrot (width, height, xc, yc, scale, use_simd) {
   logger.msg ("drawMandelbrot(xc:" + xc + ", yc:" + yc + ")");
-  mandel(width, height, xc, yc, scale, max_iterations, use_simd);
+  if (use_simd && HAS_SIMD)
+    mandelSimd(width, height, xc, yc, scale, max_iterations);
+  else
+    mandelNonSimd(width, height, xc, yc, scale, max_iterations);
   canvas.update(buffer);
 }
 

--- a/js/mandelbrot-asm.js
+++ b/js/mandelbrot-asm.js
@@ -15,13 +15,13 @@ if (typeof Math.fround == 'undefined') {
 }
 if (typeof SIMD == 'undefined') {
   // TODO maybe use the polyfill?
-  alert('SIMD not implemented in this browser');
-  throw 'SIMD not implemented in this browser';
+  alert('SIMD not implemented in this browser. SIMD speedup button is disabled');
+//  throw 'SIMD not implemented in this browser';
 } else {
   // Polyfill coercive ctor
   try {
     var x = SIMD.float32x4(1,2,3,4);
-    var y = SIMD.float32x4(x);
+    var y = SIMD.float32x4(x);1
     if (y.x != x.x || y.y != x.y || y.z != x.z || y.w != x.w)
       throw new Error('coercive ctor not implemented');
     console.log('coercive ctors are natively implemented');
@@ -310,7 +310,151 @@ function asmjsModule (global, imp, buffer) {
   return mandel;
 }
 
-var mandel = asmjsModule (this, {}, buffer);
+function nonSimdAsmjsModule (global, imp, buffer) {
+  "use asm"
+  var b8 = new global.Uint8Array(buffer);
+  var toF = global.Math.fround;
+  var imul = global.Math.imul;
+
+  const mk0 = 0x007fffff;
+  function declareHeapLength() {
+    b8[0x00ffffff] = 0;
+  }
+
+  function mandelPixelX1 (xf, yf, yd, max_iterations) {
+    xf = toF(xf);
+    yf = toF(yf);
+    yd = toF(yd);
+    max_iterations = max_iterations | 0;
+
+    var z_re  = toF(0), z_im  = toF(0);
+    var z_re2 = toF(0), z_im2 = toF(0);
+    var new_re = toF(0), new_im = toF(0);
+    var count = 0, i = 0, mi = 0;
+
+    z_re  = xf;
+    z_im  = yf;
+
+    for (i = 0; (i | 0) < (max_iterations | 0); i = (i + 1) | 0) {
+      z_re2 = toF(z_re * z_re);
+      z_im2 = toF(z_im * z_im);
+
+      if (toF(z_re2 + z_im2) > toF(4))
+        break;
+
+      new_re = toF(z_re2 - z_im2);
+      new_im = toF(toF(z_re * toF(2)) * z_im);
+      z_re   = toF(xf + new_re);
+      z_im   = toF(yf + new_im);
+      count  = (count + 1) | 0;
+    }
+    return count | 0;
+  }
+
+  function mapColorAndSetPixel (x, y, width, value, max_iterations) {
+    x = x | 0;
+    y = y | 0;
+    width = width | 0;
+    value = value | 0;
+    max_iterations = max_iterations | 0;
+
+    var rgb = 0, r = 0, g = 0, b = 0, index = 0;
+
+    index = (((imul((width >>> 0), (y >>> 0)) + x) | 0) * 4) | 0;
+    if ((value | 0) == (max_iterations | 0)) {
+      r = 0;
+      g = 0;
+      b = 0;
+    } else {
+      rgb = ~~toF(toF(toF(toF(value >>> 0) * toF(0xffff)) / toF(max_iterations >>> 0)) * toF(0xff));
+      r = rgb & 0xff;
+      g = (rgb >>> 8) & 0xff;
+      b = (rgb >>> 16) & 0xff;
+    }
+    b8[(index & mk0) >> 0] = r;
+    b8[(index & mk0) + 1 >> 0] = g;
+    b8[(index & mk0) + 2 >> 0] = b;
+    b8[(index & mk0) + 3 >> 0] = 255;
+  }
+
+  function mandelColumnX1 (x, width, height, xf, yf, yd, max_iterations) {
+    x = x | 0;
+    width = width | 0;
+    height = height | 0;
+    xf = toF(xf);
+    yf = toF(yf);
+    yd = toF(yd);
+    max_iterations = max_iterations | 0;
+
+    var y = 0, m = 0;
+
+    yd = toF(yd);
+    for (y = 0; (y | 0) < (height | 0); y = (y + 1) | 0) {
+      m = mandelPixelX1(toF(xf), toF(yf), toF(yd), max_iterations) | 0;
+      mapColorAndSetPixel(x | 0, y | 0, width, m, max_iterations);
+      yf = toF(yf + yd);
+    }
+  }
+
+  function mandelX1 (width, height, xc, yc, scale, max_iterations) {
+    width = width | 0;
+    height = height | 0;
+    xc = toF(xc);
+    yc = toF(yc);
+    scale = toF(scale);
+    max_iterations = max_iterations | 0;
+
+    var x0 = toF(0), y0 = toF(0), xd = toF(0), yd = toF(0), xf = toF(0);
+    var x = 0;
+
+    x0 = toF(xc - toF(scale * toF(1.5)));
+    y0 = toF(yc - scale);
+    xd = toF(toF(scale * toF(3)) / toF(width >>> 0));
+    yd = toF(toF(scale * toF(2)) / toF(height >>> 0));
+    xf = x0;
+
+    for (x = 0; (x | 0) < (width | 0); x = (x + 1) | 0) {
+      mandelColumnX1(x, width, height, xf, y0, yd, max_iterations);
+      xf = toF(xf + xd);
+    }
+  }
+
+  function mandel (width, height, xc, yc, scale, max_iterations, use_simd) {
+    width = width | 0;
+    height = height | 0;
+    xc = toF(xc);
+    yc = toF(yc);
+    scale = toF(scale);
+    max_iterations = max_iterations | 0;
+    use_simd = use_simd | 0;
+
+    var x0 = toF(0), y0 = toF(0);
+    var xd = toF(0), yd = toF(0);
+    var xf = toF(0);
+    var x = 0;
+
+    x0 = toF(xc - toF(scale * toF(1.5)));
+    y0 = toF(yc - scale);
+    xd = toF(toF(scale * toF(3)) / toF(width >>> 0));
+    yd = toF(toF(scale * toF(2)) / toF(height >>> 0));
+    xf = x0;
+
+    for (x = 0; (x | 0) < (width | 0); x = (x + 1) | 0) {
+      mandelColumnX1(x, width, height, xf, y0, yd, max_iterations);
+      xf = toF(xf + xd);
+    }
+  }
+
+  return mandel;
+}
+
+var mandel;
+if (typeof SIMD === "undefined") {
+  mandel = nonSimdAsmjsModule(this, {}, buffer);
+}
+else {
+  mandel = asmjsModule (this, {}, buffer);
+}
 
 function drawMandelbrot (width, height, xc, yc, scale, use_simd) {
   logger.msg ("drawMandelbrot(xc:" + xc + ", yc:" + yc + ")");

--- a/js/mandelbrot-asm.js
+++ b/js/mandelbrot-asm.js
@@ -21,7 +21,7 @@ if (typeof SIMD == 'undefined') {
   // Polyfill coercive ctor
   try {
     var x = SIMD.float32x4(1,2,3,4);
-    var y = SIMD.float32x4(x);1
+    var y = SIMD.float32x4(x);
     if (y.x != x.x || y.y != x.y || y.z != x.z || y.w != x.w)
       throw new Error('coercive ctor not implemented');
     console.log('coercive ctors are natively implemented');

--- a/js/mandelbrot-worker-asm.js
+++ b/js/mandelbrot-worker-asm.js
@@ -7,8 +7,8 @@ if (typeof Math.fround == 'undefined') {
 }
 if (typeof SIMD == 'undefined') {
   // TODO maybe use the polyfill?
-  alert('SIMD not implemented in this browser');
-  throw 'SIMD not implemented in this browser';
+//  alert('SIMD not implemented in this browser'); // NOTE: alert is not available in web workers
+//  throw 'SIMD not implemented in this browser';
 } else {
   // Polyfill coercive ctor
   try {
@@ -279,7 +279,151 @@ function asmjsModule (global, imp, buffer) {
   return mandel;
 }
 
-var mandel = asmjsModule (this, {}, buffer);
+function nonSimdAsmjsModule (global, imp, buffer) {
+  "use asm"
+  var b8 = new global.Uint8Array(buffer);
+  var toF = global.Math.fround;
+  var imul = global.Math.imul;
+
+  const mk0 = 0x007fffff;
+  function declareHeapLength() {
+    b8[0x00ffffff] = 0;
+  }
+
+  function mandelPixelX1 (xf, yf, yd, max_iterations) {
+    xf = toF(xf);
+    yf = toF(yf);
+    yd = toF(yd);
+    max_iterations = max_iterations | 0;
+
+    var z_re  = toF(0), z_im  = toF(0);
+    var z_re2 = toF(0), z_im2 = toF(0);
+    var new_re = toF(0), new_im = toF(0);
+    var count = 0, i = 0, mi = 0;
+
+    z_re  = xf;
+    z_im  = yf;
+
+    for (i = 0; (i | 0) < (max_iterations | 0); i = (i + 1) | 0) {
+      z_re2 = toF(z_re * z_re);
+      z_im2 = toF(z_im * z_im);
+
+      if (toF(z_re2 + z_im2) > toF(4))
+	break;
+
+      new_re = toF(z_re2 - z_im2);
+      new_im = toF(toF(z_re * toF(2)) * z_im);
+      z_re   = toF(xf + new_re);
+      z_im   = toF(yf + new_im);
+      count  = (count + 1) | 0;
+    }
+    return count | 0;
+  }
+
+  function mapColorAndSetPixel (x, y, width, value, max_iterations) {
+    x = x | 0;
+    y = y | 0;
+    width = width | 0;
+    value = value | 0;
+    max_iterations = max_iterations | 0;
+
+    var rgb = 0, r = 0, g = 0, b = 0, index = 0;
+
+    index = (((imul((width >>> 0), (y >>> 0)) + x) | 0) * 4) | 0;
+    if ((value | 0) == (max_iterations | 0)) {
+      r = 0;
+      g = 0;
+      b = 0;
+    } else {
+      rgb = ~~toF(toF(toF(toF(value >>> 0) * toF(0xffff)) / toF(max_iterations >>> 0)) * toF(0xff));
+      r = rgb & 0xff;
+      g = (rgb >>> 8) & 0xff;
+      b = (rgb >>> 16) & 0xff;
+    }
+    b8[(index & mk0) >> 0] = r;
+    b8[(index & mk0) + 1 >> 0] = g;
+    b8[(index & mk0) + 2 >> 0] = b;
+    b8[(index & mk0) + 3 >> 0] = 255;
+  }
+
+  function mandelColumnX1 (x, width, height, xf, yf, yd, max_iterations) {
+    x = x | 0;
+    width = width | 0;
+    height = height | 0;
+    xf = toF(xf);
+    yf = toF(yf);
+    yd = toF(yd);
+    max_iterations = max_iterations | 0;
+
+    var y = 0, m = 0;
+
+    yd = toF(yd);
+    for (y = 0; (y | 0) < (height | 0); y = (y + 1) | 0) {
+      m = mandelPixelX1(toF(xf), toF(yf), toF(yd), max_iterations) | 0;
+      mapColorAndSetPixel(x | 0, y | 0, width, m, max_iterations);
+      yf = toF(yf + yd);
+    }
+  }
+
+  function mandelX1 (width, height, xc, yc, scale, max_iterations) {
+    width = width | 0;
+    height = height | 0;
+    xc = toF(xc);
+    yc = toF(yc);
+    scale = toF(scale);
+    max_iterations = max_iterations | 0;
+
+    var x0 = toF(0), y0 = toF(0), xd = toF(0), yd = toF(0), xf = toF(0);
+    var x = 0;
+
+    x0 = toF(xc - toF(scale * toF(1.5)));
+    y0 = toF(yc - scale);
+    xd = toF(toF(scale * toF(3)) / toF(width >>> 0));
+    yd = toF(toF(scale * toF(2)) / toF(height >>> 0));
+    xf = x0;
+
+    for (x = 0; (x | 0) < (width | 0); x = (x + 1) | 0) {
+      mandelColumnX1(x, width, height, xf, y0, yd, max_iterations);
+      xf = toF(xf + xd);
+    }
+  }
+
+  function mandel (width, height, xc, yc, scale, max_iterations, use_simd) {
+    width = width | 0;
+    height = height | 0;
+    xc = toF(xc);
+    yc = toF(yc);
+    scale = toF(scale);
+    max_iterations = max_iterations | 0;
+    use_simd = use_simd | 0;
+
+    var x0 = toF(0), y0 = toF(0);
+    var xd = toF(0), yd = toF(0);
+    var xf = toF(0);
+    var x = 0;
+
+    x0 = toF(xc - toF(scale * toF(1.5)));
+    y0 = toF(yc - scale);
+    xd = toF(toF(scale * toF(3)) / toF(width >>> 0));
+    yd = toF(toF(scale * toF(2)) / toF(height >>> 0));
+    xf = x0;
+
+    for (x = 0; (x | 0) < (width | 0); x = (x + 1) | 0) {
+      mandelColumnX1(x, width, height, xf, y0, yd, max_iterations);
+      xf = toF(xf + xd);
+    }
+  }
+
+  return mandel;
+}
+
+var mandel;
+if (typeof SIMD === "undefined") {
+  mandel = nonSimdAsmjsModule(this, {}, buffer);
+}
+else {
+  mandel = asmjsModule (this, {}, buffer);
+}
 
 function drawMandelbrot (params) {
   var width          = params.width;

--- a/js/mandelbrot-worker-asm.js
+++ b/js/mandelbrot-worker-asm.js
@@ -5,11 +5,7 @@
 if (typeof Math.fround == 'undefined') {
   Math.fround = function(x) { return x };
 }
-if (typeof SIMD == 'undefined') {
-  // TODO maybe use the polyfill?
-//  alert('SIMD not implemented in this browser'); // NOTE: alert is not available in web workers
-//  throw 'SIMD not implemented in this browser';
-} else {
+if (typeof SIMD != 'undefined') {
   // Polyfill coercive ctor
   try {
     var x = SIMD.float32x4(1,2,3,4);
@@ -88,36 +84,6 @@ function asmjsModule (global, imp, buffer) {
     b8[0x00ffffff] = 0;
   }
 
-  function mandelPixelX1 (xf, yf, yd, max_iterations) {
-    xf = toF(xf);
-    yf = toF(yf);
-    yd = toF(yd);
-    max_iterations = max_iterations | 0;
-
-    var z_re  = toF(0), z_im  = toF(0);
-    var z_re2 = toF(0), z_im2 = toF(0);
-    var new_re = toF(0), new_im = toF(0);
-    var count = 0, i = 0, mi = 0;
-
-    z_re  = xf;
-    z_im  = yf;
-
-    for (i = 0; (i | 0) < (max_iterations | 0); i = (i + 1) | 0) {
-      z_re2 = toF(z_re * z_re);
-      z_im2 = toF(z_im * z_im);
-
-      if (toF(z_re2 + z_im2) > toF(4))
-	break;
-
-      new_re = toF(z_re2 - z_im2);
-      new_im = toF(toF(z_re * toF(2)) * z_im);
-      z_re   = toF(xf + new_re);
-      z_im   = toF(yf + new_im);
-      count  = (count + 1) | 0;
-    }
-    return count | 0;
-  }
-
   function mapColorAndSetPixel (x, y, width, value, max_iterations) {
     x = x | 0;
     y = y | 0;
@@ -142,48 +108,6 @@ function asmjsModule (global, imp, buffer) {
     b8[(index & mk0) + 1 >> 0] = g;
     b8[(index & mk0) + 2 >> 0] = b;
     b8[(index & mk0) + 3 >> 0] = 255;
-  }
-
-  function mandelColumnX1 (x, width, height, xf, yf, yd, max_iterations) {
-    x = x | 0;
-    width = width | 0;
-    height = height | 0;
-    xf = toF(xf);
-    yf = toF(yf);
-    yd = toF(yd);
-    max_iterations = max_iterations | 0;
-
-    var y = 0, m = 0;
-
-    yd = toF(yd);
-    for (y = 0; (y | 0) < (height | 0); y = (y + 1) | 0) {
-      m = mandelPixelX1(toF(xf), toF(yf), toF(yd), max_iterations) | 0;
-      mapColorAndSetPixel(x | 0, y | 0, width, m, max_iterations);
-      yf = toF(yf + yd);
-    }
-  }
-
-  function mandelX1 (width, height, xc, yc, scale, max_iterations) {
-    width = width | 0;
-    height = height | 0;
-    xc = toF(xc);
-    yc = toF(yc);
-    scale = toF(scale);
-    max_iterations = max_iterations | 0;
-
-    var x0 = toF(0), y0 = toF(0), xd = toF(0), yd = toF(0), xf = toF(0);
-    var x = 0;
-
-    x0 = toF(xc - toF(scale * toF(1.5)));
-    y0 = toF(yc - scale);
-    xd = toF(toF(scale * toF(3)) / toF(width >>> 0));
-    yd = toF(toF(scale * toF(2)) / toF(height >>> 0));
-    xf = x0;
-
-    for (x = 0; (x | 0) < (width | 0); x = (x + 1) | 0) {
-      mandelColumnX1(x, width, height, xf, y0, yd, max_iterations);
-      xf = toF(xf + xd);
-    }
   }
 
   function mandelPixelX4 (xf, yf, yd, max_iterations) {
@@ -247,14 +171,13 @@ function asmjsModule (global, imp, buffer) {
     }
   }
 
-  function mandel (width, height, xc, yc, scale, max_iterations, use_simd) {
+  function mandel (width, height, xc, yc, scale, max_iterations) {
     width = width | 0;
     height = height | 0;
     xc = toF(xc);
     yc = toF(yc);
     scale = toF(scale);
     max_iterations = max_iterations | 0;
-    use_simd = use_simd | 0;
 
     var x0 = toF(0), y0 = toF(0);
     var xd = toF(0), yd = toF(0);
@@ -268,10 +191,7 @@ function asmjsModule (global, imp, buffer) {
     xf = x0;
 
     for (x = 0; (x | 0) < (width | 0); x = (x + 1) | 0) {
-      if (use_simd)
-        mandelColumnX4(x, width, height, xf, y0, yd, max_iterations);
-      else
-        mandelColumnX1(x, width, height, xf, y0, yd, max_iterations);
+      mandelColumnX4(x, width, height, xf, y0, yd, max_iterations);
       xf = toF(xf + xd);
     }
   }
@@ -309,7 +229,7 @@ function nonSimdAsmjsModule (global, imp, buffer) {
       z_im2 = toF(z_im * z_im);
 
       if (toF(z_re2 + z_im2) > toF(4))
-	break;
+        break;
 
       new_re = toF(z_re2 - z_im2);
       new_im = toF(toF(z_re * toF(2)) * z_im);
@@ -329,7 +249,7 @@ function nonSimdAsmjsModule (global, imp, buffer) {
 
     var rgb = 0, r = 0, g = 0, b = 0, index = 0;
 
-    index = (((imul((width >>> 0), (y >>> 0)) + x) | 0) * 4) | 0;
+    index = ((((imul((width >>> 0), (y >>> 0)) | 0) + x) | 0) * 4) | 0;
     if ((value | 0) == (max_iterations | 0)) {
       r = 0;
       g = 0;
@@ -388,14 +308,13 @@ function nonSimdAsmjsModule (global, imp, buffer) {
     }
   }
 
-  function mandel (width, height, xc, yc, scale, max_iterations, use_simd) {
+  function mandel (width, height, xc, yc, scale, max_iterations) {
     width = width | 0;
     height = height | 0;
     xc = toF(xc);
     yc = toF(yc);
     scale = toF(scale);
     max_iterations = max_iterations | 0;
-    use_simd = use_simd | 0;
 
     var x0 = toF(0), y0 = toF(0);
     var xd = toF(0), yd = toF(0);
@@ -417,13 +336,9 @@ function nonSimdAsmjsModule (global, imp, buffer) {
   return mandel;
 }
 
-var mandel;
-if (typeof SIMD === "undefined") {
-  mandel = nonSimdAsmjsModule(this, {}, buffer);
-}
-else {
-  mandel = asmjsModule (this, {}, buffer);
-}
+var HAS_SIMD = typeof SIMD !== 'undefined';
+var mandelSimd = (HAS_SIMD && asmjsModule (this, {}, buffer)) || null;
+var mandelNonSimd = nonSimdAsmjsModule (this, {}, buffer);
 
 function drawMandelbrot (params) {
   var width          = params.width;
@@ -434,5 +349,8 @@ function drawMandelbrot (params) {
   var yc             = params.yc;
   var max_iterations = params.max_iterations;
 
-  mandel(width, height, xc, yc, scale, max_iterations, use_simd);
+  if (use_simd && HAS_SIMD)
+    mandelSimd(width, height, xc, yc, scale, max_iterations);
+  else
+    mandelNonSimd(width, height, xc, yc, scale, max_iterations);
 }


### PR DESCRIPTION
Hi @PeterJensen 
I like your idea of having two distinct asm.js modules, as it will help both Chromium and versions of Firefox which don't have the SIMD global object. Great job!

Unfortunately, the non SIMD demo didn't compile in the current Firefox release because of a little thing (calls to imul() had to be coerced before). This pull request is based on yours, and adds the following:
- coercion of the call to imul()
- removed the methods unused in mandelX4
- use_simd wasn't needed in any of the asm.js modules => delete it
- rather than compiling a module on demand if SIMD is present, we compile both and do the switch in the draw function itself, using the param.use_simd and HAS_SIMD (const that effectively checks if we have SIMD enabled).

If that's fine for you, I propose to merge this one and close the other one. Please let me know if you have any remarks about this change.
Cheers!
