### PR TITLE
Use SIMD.check in asm.js variants

### DIFF
--- a/js/mandelbrot-asm.js
+++ b/js/mandelbrot-asm.js
@@ -104,6 +104,7 @@ function asmjsModule (global, imp, buffer) {
   var f4 = global.SIMD.float32x4;
   var i4add = i4.add;
   var i4and = i4.and;
+  var i4check = i4.check;
   var f4add = f4.add;
   var f4sub = f4.sub;
   var f4mul = f4.mul;
@@ -177,7 +178,7 @@ function asmjsModule (global, imp, buffer) {
       z_im4   = f4add(c_im4, new_im4);
       count4  = i4add(count4, i4and(mi4, one4));
     }
-    return i4(count4);
+    return i4check(count4);
   }
 
   function mandelColumnX4 (x, width, height, xf, yf, yd, max_iterations) {
@@ -195,7 +196,7 @@ function asmjsModule (global, imp, buffer) {
 
     ydx4 = toF(yd * toF(4));
     for (y = 0; (y | 0) < (height | 0); y = (y + 4) | 0) {
-      m4   = i4(mandelPixelX4(toF(xf), toF(yf), toF(yd), max_iterations));
+      m4   = i4check(mandelPixelX4(toF(xf), toF(yf), toF(yd), max_iterations));
       mapColorAndSetPixel(x | 0, y | 0,   width, m4.x, max_iterations);
       mapColorAndSetPixel(x | 0, (y + 1) | 0, width, m4.y, max_iterations);
       mapColorAndSetPixel(x | 0, (y + 2) | 0, width, m4.z, max_iterations);

--- a/js/mandelbrot-worker-asm.js
+++ b/js/mandelbrot-worker-asm.js
@@ -71,6 +71,7 @@ function asmjsModule (global, imp, buffer) {
   var f4 = global.SIMD.float32x4;
   var i4add = i4.add;
   var i4and = i4.and;
+  var i4check = i4.check;
   var f4add = f4.add;
   var f4sub = f4.sub;
   var f4mul = f4.mul;
@@ -144,7 +145,7 @@ function asmjsModule (global, imp, buffer) {
       z_im4   = f4add(c_im4, new_im4);
       count4  = i4add(count4, i4and(mi4, one4));
     }
-    return i4(count4);
+    return i4check(count4);
   }
 
   function mandelColumnX4 (x, width, height, xf, yf, yd, max_iterations) {
@@ -162,7 +163,7 @@ function asmjsModule (global, imp, buffer) {
 
     ydx4 = toF(yd * toF(4));
     for (y = 0; (y | 0) < (height | 0); y = (y + 4) | 0) {
-      m4   = i4(mandelPixelX4(toF(xf), toF(yf), toF(yd), max_iterations));
+      m4   = i4check(mandelPixelX4(toF(xf), toF(yf), toF(yd), max_iterations));
       mapColorAndSetPixel(x | 0, y | 0,   width, m4.x, max_iterations);
       mapColorAndSetPixel(x | 0, (y + 1) | 0, width, m4.y, max_iterations);
       mapColorAndSetPixel(x | 0, (y + 2) | 0, width, m4.z, max_iterations);


### PR DESCRIPTION
Now that SIMD.check has been implemented in Odinmonkey (implementation of asm.js in Firefox), it needs to be used in asm.js code, otherwise it will trigger validation errors and the code will be ultra-slow.

@PeterJensen can you take a look at it please? Without this patch, the demo won't validate on Nightlies, as of tomorrow.