### PR TITLE
Update mandelbrot-asm.js to use boolean vectors.

### DIFF
--- a/js/mandelbrot-asm.js
+++ b/js/mandelbrot-asm.js
@@ -72,9 +72,10 @@ function asmjsModule (global, imp, buffer) {
   var toF = global.Math.fround;
   var i4 = global.SIMD.Int32x4;
   var f4 = global.SIMD.Float32x4;
-  var i4ext = i4.extractLane;
   var i4add = i4.add;
   var i4and = i4.and;
+  var i4ext = i4.extractLane;
+  var i4sel = i4.select;
   var i4check = i4.check;
   var f4add = f4.add;
   var f4sub = f4.sub;
@@ -82,9 +83,12 @@ function asmjsModule (global, imp, buffer) {
   var f4lessThanOrEqual = f4.lessThanOrEqual;
   var f4splat = f4.splat;
   var imul = global.Math.imul;
-  const one4 = i4(1,1,1,1), two4 = f4(2,2,2,2), four4 = f4(4,4,4,4);
+  var b4 = global.SIMD.Bool32x4;
+  var b4any = b4.anyTrue;
+  const zero4 = i4(0,0,0,0), one4 = i4(1,1,1,1), two4 = f4(2,2,2,2), four4 = f4(4,4,4,4);
 
   const mk0 = 0x007fffff;
+
   function declareHeapLength() {
     b8[0x00ffffff] = 0;
   }
@@ -126,7 +130,7 @@ function asmjsModule (global, imp, buffer) {
     var z_re24 = f4(0,0,0,0), z_im24 = f4(0,0,0,0);
     var new_re4 = f4(0,0,0,0), new_im4 = f4(0,0,0,0);
     var i = 0;
-    var mi4 = i4(0,0,0,0);
+    var mb4 = b4(0,0,0,0);
 
     c_re4 = f4splat(xf);
     c_im4 = f4(yf, toF(yd + yf), toF(yd + toF(yd + yf)), toF(yd + toF(yd + toF(yd + yf))));
@@ -138,16 +142,16 @@ function asmjsModule (global, imp, buffer) {
       z_re24 = f4mul(z_re4, z_re4);
       z_im24 = f4mul(z_im4, z_im4);
 
-      mi4 = f4lessThanOrEqual(f4add(z_re24, z_im24), four4);
+      mb4 = f4lessThanOrEqual(f4add(z_re24, z_im24), four4);
       // If all 4 values are greater than 4.0, there's no reason to continue.
-      if ((mi4.signMask | 0) == 0x00)
+      if (!b4any(mb4))
         break;
 
       new_re4 = f4sub(z_re24, z_im24);
       new_im4 = f4mul(f4mul(two4, z_re4), z_im4);
       z_re4   = f4add(c_re4, new_re4);
       z_im4   = f4add(c_im4, new_im4);
-      count4  = i4add(count4, i4and(mi4, one4));
+      count4  = i4add(count4, i4sel(mb4, one4, zero4));
     }
     return i4check(count4);
   }

--- a/js/mandelbrot-worker-asm.js
+++ b/js/mandelbrot-worker-asm.js
@@ -37,9 +37,10 @@ function asmjsModule (global, imp, buffer) {
   var toF = global.Math.fround;
   var i4 = global.SIMD.Int32x4;
   var f4 = global.SIMD.Float32x4;
-  var i4ext = i4.extractLane;
   var i4add = i4.add;
   var i4and = i4.and;
+  var i4ext = i4.extractLane;
+  var i4sel = i4.select;
   var i4check = i4.check;
   var f4add = f4.add;
   var f4sub = f4.sub;
@@ -47,9 +48,12 @@ function asmjsModule (global, imp, buffer) {
   var f4lessThanOrEqual = f4.lessThanOrEqual;
   var f4splat = f4.splat;
   var imul = global.Math.imul;
-  const one4 = i4(1,1,1,1), two4 = f4(2,2,2,2), four4 = f4(4,4,4,4);
+  var b4 = global.SIMD.Bool32x4;
+  var b4any = b4.anyTrue;
+  const zero4 = i4(0,0,0,0), one4 = i4(1,1,1,1), two4 = f4(2,2,2,2), four4 = f4(4,4,4,4);
 
   const mk0 = 0x007fffff;
+
   function declareHeapLength() {
     b8[0x00ffffff] = 0;
   }
@@ -91,7 +95,7 @@ function asmjsModule (global, imp, buffer) {
     var z_re24 = f4(0,0,0,0), z_im24 = f4(0,0,0,0);
     var new_re4 = f4(0,0,0,0), new_im4 = f4(0,0,0,0);
     var i = 0;
-    var mi4 = i4(0,0,0,0);
+    var mb4 = b4(0,0,0,0);
 
     c_re4 = f4splat(xf);
     c_im4 = f4(yf, toF(yd + yf), toF(yd + toF(yd + yf)), toF(yd + toF(yd + toF(yd + yf))));
@@ -103,16 +107,16 @@ function asmjsModule (global, imp, buffer) {
       z_re24 = f4mul(z_re4, z_re4);
       z_im24 = f4mul(z_im4, z_im4);
 
-      mi4 = f4lessThanOrEqual(f4add(z_re24, z_im24), four4);
+      mb4 = f4lessThanOrEqual(f4add(z_re24, z_im24), four4);
       // If all 4 values are greater than 4.0, there's no reason to continue.
-      if ((mi4.signMask | 0) == 0x00)
+      if (!b4any(mb4))
         break;
 
       new_re4 = f4sub(z_re24, z_im24);
       new_im4 = f4mul(f4mul(two4, z_re4), z_im4);
       z_re4   = f4add(c_re4, new_re4);
       z_im4   = f4add(c_im4, new_im4);
-      count4  = i4add(count4, i4and(mi4, one4));
+      count4  = i4add(count4, i4sel(mb4, one4, zero4));
     }
     return i4check(count4);
   }

--- a/js/mandelbrot-worker.js
+++ b/js/mandelbrot-worker.js
@@ -41,26 +41,27 @@ function mandelx1 (c_re, c_im) {
 function mandelx4(c_re4, c_im4) {
   var z_re4  = c_re4;
   var z_im4  = c_im4;
-  var four4  = SIMD.float32x4.splat (4.0);
-  var two4   = SIMD.float32x4.splat (2.0);
-  var count4 = SIMD.int32x4.splat (0);
-  var one4   = SIMD.int32x4.splat (1);
+  var four4  = SIMD.Float32x4.splat (4.0);
+  var two4   = SIMD.Float32x4.splat (2.0);
+  var count4 = SIMD.Int32x4.splat (0);
+  var zero4  = SIMD.Int32x4.splat (0);
+  var one4   = SIMD.Int32x4.splat (1);
 
   for (var i = 0; i < max_iterations; ++i) {
-    var z_re24 = SIMD.float32x4.mul (z_re4, z_re4);
-    var z_im24 = SIMD.float32x4.mul (z_im4, z_im4);
+    var z_re24 = SIMD.Float32x4.mul (z_re4, z_re4);
+    var z_im24 = SIMD.Float32x4.mul (z_im4, z_im4);
 
-    var mi4    = SIMD.float32x4.lessThanOrEqual (SIMD.float32x4.add (z_re24, z_im24), four4);
+    var mb4    = SIMD.Float32x4.lessThanOrEqual (SIMD.Float32x4.add (z_re24, z_im24), four4);
     // if all 4 values are greater than 4.0, there's no reason to continue
-    if (mi4.signMask === 0x00) {
+    if (!SIMD.Bool32x4.anyTrue(mb4)) {
       break;
     }
 
-    var new_re4 = SIMD.float32x4.sub (z_re24, z_im24);
-    var new_im4 = SIMD.float32x4.mul (SIMD.float32x4.mul (two4, z_re4), z_im4);
-    z_re4       = SIMD.float32x4.add (c_re4, new_re4);
-    z_im4       = SIMD.float32x4.add (c_im4, new_im4);
-    count4      = SIMD.int32x4.add (count4, SIMD.int32x4.and (mi4, one4));
+    var new_re4 = SIMD.Float32x4.sub (z_re24, z_im24);
+    var new_im4 = SIMD.Float32x4.mul (SIMD.Float32x4.mul (two4, z_re4), z_im4);
+    z_re4       = SIMD.Float32x4.add (c_re4, new_re4);
+    z_im4       = SIMD.Float32x4.add (c_im4, new_im4);
+    count4      = SIMD.Int32x4.add (count4, SIMD.Int32x4.select (mb4, one4, zero4));
   }
   return count4;
 }
@@ -103,13 +104,13 @@ function drawMandelbrot (params) {
     if (use_simd) {
       var ydx4 = 4*yd;
       for (var y = 0; y < height; y += 4) {
-        var xf4 = SIMD.float32x4(xf, xf, xf, xf);
-        var yf4 = SIMD.float32x4(yf, yf+yd, yf+yd+yd, yf+yd+yd+yd);
+        var xf4 = SIMD.Float32x4(xf, xf, xf, xf);
+        var yf4 = SIMD.Float32x4(yf, yf+yd, yf+yd+yd, yf+yd+yd+yd);
         var m4   = mandelx4 (xf4, yf4);
-        mapColorAndSetPixel (x, y,   m4.x);
-        mapColorAndSetPixel (x, y+1, m4.y);
-        mapColorAndSetPixel (x, y+2, m4.z);
-        mapColorAndSetPixel (x, y+3, m4.w);
+        mapColorAndSetPixel (x, y,   SIMD.Int32x4.extractLane(m4, 0));
+        mapColorAndSetPixel (x, y+1, SIMD.Int32x4.extractLane(m4, 1));
+        mapColorAndSetPixel (x, y+2, SIMD.Int32x4.extractLane(m4, 2));
+        mapColorAndSetPixel (x, y+3, SIMD.Int32x4.extractLane(m4, 3));
         yf += ydx4;
       }
     }

--- a/js/mandelbrot.js
+++ b/js/mandelbrot.js
@@ -124,26 +124,27 @@ function mandelx1 (c_re, c_im) {
 function mandelx4(c_re4, c_im4) {
   var z_re4  = c_re4;
   var z_im4  = c_im4;
-  var four4  = SIMD.float32x4.splat (4.0);
-  var two4   = SIMD.float32x4.splat (2.0);
-  var count4 = SIMD.int32x4.splat (0);
-  var one4   = SIMD.int32x4.splat (1);
+  var four4  = SIMD.Float32x4.splat (4.0);
+  var two4   = SIMD.Float32x4.splat (2.0);
+  var count4 = SIMD.Int32x4.splat (0);
+  var zero4  = SIMD.Int32x4.splat (0);
+  var one4   = SIMD.Int32x4.splat (1);
 
   for (var i = 0; i < max_iterations; ++i) {
-    var z_re24 = SIMD.float32x4.mul (z_re4, z_re4);
-    var z_im24 = SIMD.float32x4.mul (z_im4, z_im4);
+    var z_re24 = SIMD.Float32x4.mul (z_re4, z_re4);
+    var z_im24 = SIMD.Float32x4.mul (z_im4, z_im4);
 
-    var mi4    = SIMD.float32x4.lessThanOrEqual (SIMD.float32x4.add (z_re24, z_im24), four4);
+    var mb4    = SIMD.Float32x4.lessThanOrEqual (SIMD.Float32x4.add (z_re24, z_im24), four4);
     // if all 4 values are greater than 4.0, there's no reason to continue
-    if (mi4.signMask === 0x00) {
+    if (!SIMD.Bool32x4.anyTrue(mb4)) {
       break;
     }
 
-    var new_re4 = SIMD.float32x4.sub (z_re24, z_im24);
-    var new_im4 = SIMD.float32x4.mul (SIMD.float32x4.mul (two4, z_re4), z_im4);
-    z_re4       = SIMD.float32x4.add (c_re4, new_re4);
-    z_im4       = SIMD.float32x4.add (c_im4, new_im4);
-    count4      = SIMD.int32x4.add (count4, SIMD.int32x4.and (mi4, one4));
+    var new_re4 = SIMD.Float32x4.sub (z_re24, z_im24);
+    var new_im4 = SIMD.Float32x4.mul (SIMD.Float32x4.mul (two4, z_re4), z_im4);
+    z_re4       = SIMD.Float32x4.add (c_re4, new_re4);
+    z_im4       = SIMD.Float32x4.add (c_im4, new_im4);
+    count4      = SIMD.Int32x4.add (count4, SIMD.Int32x4.select (mb4, one4, zero4));
   }
   return count4;
 }
@@ -162,13 +163,13 @@ function drawMandelbrot (width, height, xc, yc, scale, use_simd) {
     if (use_simd) {
       var ydx4 = 4*yd;
       for (var y = 0; y < height; y += 4) {
-        var xf4 = SIMD.float32x4(xf, xf, xf, xf);
-        var yf4 = SIMD.float32x4(yf, yf+yd, yf+yd+yd, yf+yd+yd+yd);
+        var xf4 = SIMD.Float32x4(xf, xf, xf, xf);
+        var yf4 = SIMD.Float32x4(yf, yf+yd, yf+yd+yd, yf+yd+yd+yd);
         var m4   = mandelx4 (xf4, yf4);
-        canvas.mapColorAndSetPixel (x, y,   m4.x);
-        canvas.mapColorAndSetPixel (x, y+1, m4.y);
-        canvas.mapColorAndSetPixel (x, y+2, m4.z);
-        canvas.mapColorAndSetPixel (x, y+3, m4.w);
+        canvas.mapColorAndSetPixel (x, y,   SIMD.Int32x4.extractLane(m4, 0));
+        canvas.mapColorAndSetPixel (x, y+1, SIMD.Int32x4.extractLane(m4, 1));
+        canvas.mapColorAndSetPixel (x, y+2, SIMD.Int32x4.extractLane(m4, 2));
+        canvas.mapColorAndSetPixel (x, y+3, SIMD.Int32x4.extractLane(m4, 3));
         yf += ydx4;
       }
     }


### PR DESCRIPTION
The SIMD.js spec (v0.9) now has boolean vectors, and
Float32x4.lessThanOrEqual() returns a Bool32x4 vector.

Update the mandelPixelX4() function to expect this new return type from the
comparison.
